### PR TITLE
Parse function in RemoteDocumentation facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ You can then edit `resources/views/vendor/remote-documentation/layout.blade.php`
 
 ---
 
-## 🛠 Available Services
+## 🛠 Available functions
 
-You can use services manually if needed:
+The following functions are available through the `RemoteDocumentation` facade.
 
-| Service | Purpose |
-|:---|:---|
+| Service                                  | Purpose |
+|:-----------------------------------------|:---|
 | `RemoteDocumentation::get($repo, $file)` | Fetch and parse remote Markdown |
-| `FileGenerateService::generate($repo, $file)` | Generate a Blade view file |
+| `RemoteDocumentation::parse($markdown)`  | Generate a Blade view file |
 
 All services are fully extensible and injectable for advanced use cases.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "veiliglanceren/laravel-remote-documentation",
     "description": "Easily fetch, parse, and display remote Markdown documentation from GitHub (or other sources) directly into customizable Blade views in your Laravel application.",
     "type": "library",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "require": {
         "php": "^8.1",
         "laravel/framework": "^10.0|^11.0|^12.0",

--- a/src/Facades/RemoteDocumentation.php
+++ b/src/Facades/RemoteDocumentation.php
@@ -7,6 +7,7 @@ use Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services\IRemoteDocumen
 
 /**
  * @method static string get(string $repository, string $file = 'README.md')
+ * @method static string parse(string $markdown)
  *
  * @see \Veiliglanceren\LaravelRemoteDocumentation\Services\IRemoteDocumentationService
  */

--- a/src/Interfaces/Services/IRemoteDocumentationService.php
+++ b/src/Interfaces/Services/IRemoteDocumentationService.php
@@ -2,12 +2,27 @@
 
 namespace Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services;
 
+use League\CommonMark\Exception\CommonMarkException;
+use Veiliglanceren\LaravelRemoteDocumentation\Exceptions\ParseMarkdownException;
+use Veiliglanceren\LaravelRemoteDocumentation\Exceptions\FetchDocumentationException;
+
 interface IRemoteDocumentationService
 {
     /**
      * @param string $repo
      * @param string $file
      * @return string
+     * @throws CommonMarkException
+     * @throws ParseMarkdownException
+     * @throws FetchDocumentationException
      */
     public function get(string $repo, string $file = 'README.md'): string;
+
+    /**
+     * @param string $markdown
+     * @return string
+     * @throws CommonMarkException
+     * @throws ParseMarkdownException
+     */
+    public function parse(string $markdown): string;
 }

--- a/src/Services/RemoteDocumentationService.php
+++ b/src/Services/RemoteDocumentationService.php
@@ -2,6 +2,9 @@
 
 namespace Veiliglanceren\LaravelRemoteDocumentation\Services;
 
+use League\CommonMark\Exception\CommonMarkException;
+use Veiliglanceren\LaravelRemoteDocumentation\Exceptions\FetchDocumentationException;
+use Veiliglanceren\LaravelRemoteDocumentation\Exceptions\ParseMarkdownException;
 use Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services\IParseService;
 use Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services\IGithubService;
 use Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services\IRemoteDocumentationService;
@@ -24,6 +27,14 @@ class RemoteDocumentationService implements IRemoteDocumentationService
     {
         $markdown = $this->githubService->fetch($repo, $file);
 
+        return $this->parseService->toHtml($markdown);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse(string $markdown): string
+    {
         return $this->parseService->toHtml($markdown);
     }
 }

--- a/tests/Unit/Facades/RemoteDocumentationTest.php
+++ b/tests/Unit/Facades/RemoteDocumentationTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Veiliglanceren\LaravelRemoteDocumentation\Facades\RemoteDocumentation;
+use Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services\IParseService;
 use Veiliglanceren\LaravelRemoteDocumentation\Interfaces\Services\IRemoteDocumentationService;
+use Veiliglanceren\LaravelRemoteDocumentation\Services\RemoteDocumentationService;
 
 it('forwards calls to the RemoteDocumentationService', function () {
     $mock = Mockery::mock(IRemoteDocumentationService::class);
@@ -16,3 +18,12 @@ it('forwards calls to the RemoteDocumentationService', function () {
 
     expect($result)->toBe('<h1>Test</h1>');
 });
+
+it( 'can convert markdown to html',
+    function () {
+        $service = app(IRemoteDocumentationService::class);
+
+        $html = $service->parse('# Hello');
+
+        expect($html)->toContain('<h1>Hello</h1>');
+    });


### PR DESCRIPTION
- Added function `parse` in the RemoteDocumentation facade
- Added unit test for service function
- Updated README with the facade functions instead of direct service usage